### PR TITLE
fix: add gatsby site url env variable

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Build with Gatsby
         env:
           PREFIX_PATHS: 'true'
+          GATSBY_DEFAULT_SITE_URL: https://cloudnative-amsterdam.github.io/kcd-utrecht-website
+          GATSBY_DEV_SSR: false
+
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2


### PR DESCRIPTION
add gatsby env variables for build